### PR TITLE
rewrite to not use eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ Returns:
 
 	mocha
 
-### Note
-
-As with normal strings, **user input should be sanitised before use**, to stop users injecting <script> tags etc.
-
 ### Issues
 
 Everything works, AFAIK, if it doesn't, send a PR rather than complaining otherwise I will mock you.

--- a/index.js
+++ b/index.js
@@ -1,8 +1,1 @@
-function makeTemplate(templateString, templateVariables) {
-	const keys = Object.keys(templateVariables);
-	const values = Object.values(templateVariables);
-	let templateFunction = new Function(...keys, `return \`${templateString}\`;`);
-	return templateFunction(...values);
-}
-
-module.exports = makeTemplate
+module.exports = (templateString, templateVariables) => templateString.replace(/\${(.*?)}/g, (_, g) => templateVariables[g]);


### PR DESCRIPTION
This simple function can be achieved without eval (or eval-esque things like `new Function(...)`), and using eval causes problems for any site that uses [Content Security Policy](https://en.wikipedia.org/wiki/Content_Security_Policy).